### PR TITLE
feat: add di helpers, add testing override helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,9 @@ import asyncio
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
-from dishka import AsyncContainer, FromDishka
 from dishka.integrations.base import wrap_injection
 from waku import WakuFactory, module
-from waku.di import provider
+from waku.di import AsyncContainer, Injected, scoped
 
 P = ParamSpec('P')
 T = TypeVar('T')
@@ -124,7 +123,7 @@ class GreetingService:
 
 
 # Define a module with your providers
-@module(providers=[provider(GreetingService)])
+@module(providers=[scoped(GreetingService)])
 class GreetingModule:
     pass
 
@@ -148,7 +147,7 @@ def _inject(func: Callable[P, T]) -> Callable[P, T]:
 # Define entrypoints
 # In a real-world scenario, this could be FastAPI routes, etc.
 @_inject
-async def greet_user(container: AsyncContainer, greeting_service: FromDishka[GreetingService]) -> str:
+async def greet_user(container: AsyncContainer, greeting_service: Injected[GreetingService]) -> str:
     return greeting_service.greet('waku')
 
 

--- a/docs/code/examples/mediator.py
+++ b/docs/code/examples/mediator.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from typing import Any, ParamSpec, TypeVar
 from uuid import UUID, uuid4
 
-from dishka import AsyncContainer, FromDishka
 from dishka.integrations.base import wrap_injection
 
 from waku import WakuApplication, WakuFactory
+from waku.di import AsyncContainer, Injected
 from waku.mediator import (
     IMediator,
     MediatorConfig,
@@ -120,7 +120,7 @@ def _inject(func: Callable[P, T]) -> Callable[P, T]:
 @_inject
 async def handler(
     container: AsyncContainer,  # noqa: ARG001
-    mediator: FromDishka[IMediator],
+    mediator: Injected[IMediator],
 ) -> None:
     command = CreateMeetingCommand(user_id=uuid4())
     await mediator.send(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "anyio",
   "dishka>=1.5.3",
   "typing-extensions>=4.12",
 ]
@@ -64,7 +65,6 @@ lint = [
   "ruff>=0.11.2",
 ]
 test = [
-  "anyio>=4.9.0",
   "pytest>=8.3.5",
   "pytest-archon>=0.0.6",
   "pytest-clarity>=1.0.1",
@@ -72,6 +72,8 @@ test = [
   "pytest-mock>=3.14.0",
   "pytest-randomly>=3.16.0",
   "pytest-timeout>=2.3.1",
+  "trio>=0.30.0",
+  "uvloop>=0.21.0",
 ]
 typecheck = [
   "basedpyright>=1.28.3",

--- a/src/waku/di.py
+++ b/src/waku/di.py
@@ -1,10 +1,24 @@
 from collections.abc import Callable
 from typing import Any
 
-from dishka import Provider, Scope
+from dishka import (
+    AsyncContainer,
+    FromDishka as Injected,
+    Provider,
+    Scope,
+)
 
 __all__ = [
+    'AsyncContainer',
+    'Injected',
+    'Provider',
+    'Scope',
+    'contextual',
+    'object_',
     'provider',
+    'scoped',
+    'singleton',
+    'transient',
 ]
 
 
@@ -18,4 +32,51 @@ def provider(
     """Helper function to create a provider inplace."""
     provider_ = Provider(scope=scope)
     provider_.provide(source, provides=provided_type, cache=cache)
+    return provider_
+
+
+def singleton(
+    source: Callable[..., Any] | type[Any],
+    *,
+    provided_type: Any = None,
+) -> Provider:
+    """Helper function to create a singleton provider inplace."""
+    return provider(source, scope=Scope.APP, provided_type=provided_type)
+
+
+def scoped(
+    source: Callable[..., Any] | type[Any],
+    *,
+    provided_type: Any = None,
+) -> Provider:
+    """Helper function to create a scoped provider inplace."""
+    return provider(source, scope=Scope.REQUEST, provided_type=provided_type)
+
+
+def transient(
+    source: Callable[..., Any] | type[Any],
+    *,
+    provided_type: Any = None,
+) -> Provider:
+    """Helper function to create a transient provider inplace."""
+    return provider(source, scope=Scope.REQUEST, provided_type=provided_type, cache=False)
+
+
+def object_(
+    source: Any,
+    *,
+    provided_type: Any = None,
+) -> Provider:
+    """Helper function to create an object provider inplace."""
+    return provider(lambda: source, scope=Scope.APP, provided_type=provided_type, cache=True)
+
+
+def contextual(
+    provided_type: Any,
+    *,
+    scope: Scope = Scope.REQUEST,
+) -> Provider:
+    """Helper function to create a contextual provider inplace."""
+    provider_ = Provider()
+    provider_.from_context(provided_type, scope=scope)
     return provider_

--- a/src/waku/factory.py
+++ b/src/waku/factory.py
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from uuid import UUID
 
-    from dishka import AsyncContainer, Provider
+    from dishka.provider import BaseProvider
 
+    from waku.di import AsyncContainer
     from waku.extensions import ApplicationExtension
     from waku.lifespan import LifespanFunc
     from waku.modules import DynamicModule, ModuleType
@@ -30,7 +31,7 @@ class WakuFactory:
         lifespan: Sequence[LifespanFunc] = (),
         extensions: Sequence[ApplicationExtension] = DEFAULT_EXTENSIONS,
     ) -> None:
-        self._providers: list[Provider] = []
+        self._providers: list[BaseProvider] = []
         self._context = context
         self._container: AsyncContainer | None = None
 

--- a/src/waku/mediator/events/publish.py
+++ b/src/waku/mediator/events/publish.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Protocol
+
+import anyio
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -29,6 +30,6 @@ class SequentialEventPublisher(EventPublisher):
 
 class GroupEventPublisher(EventPublisher):
     async def __call__(self, handlers: Sequence[EventHandler[EventT]], event: EventT) -> None:
-        async with asyncio.TaskGroup() as tg:
+        async with anyio.create_task_group() as tg:
             for handler in handlers:
-                tg.create_task(handler.handle(event))
+                tg.start_soon(handler.handle, event)

--- a/src/waku/mediator/impl.py
+++ b/src/waku/mediator/impl.py
@@ -1,8 +1,8 @@
 from typing import cast
 
-from dishka import AsyncContainer
 from typing_extensions import override
 
+from waku.di import AsyncContainer
 from waku.mediator._utils import get_request_response_type
 from waku.mediator.contracts.event import Event, EventT
 from waku.mediator.contracts.request import Request, ResponseT

--- a/src/waku/mediator/middlewares.py
+++ b/src/waku/mediator/middlewares.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, TypeAlias, TypeVar
 from waku.mediator.contracts.request import Request, Response
 
 if TYPE_CHECKING:
-    from dishka import AsyncContainer
+    from waku.di import AsyncContainer
 
 
 __all__ = [

--- a/src/waku/modules/_metadata.py
+++ b/src/waku/modules/_metadata.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Final, Protocol, TypeAlias, TypeVar, cast
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from dishka import Provider
+    from dishka.provider import BaseProvider
 
     from waku.extensions import ModuleExtension
 
@@ -30,7 +30,7 @@ MODULE_METADATA_KEY: Final = '__module_metadata__'
 
 @dataclass(kw_only=True, slots=True)
 class ModuleMetadata:
-    providers: list[Provider] = field(default_factory=list)
+    providers: list[BaseProvider] = field(default_factory=list)
     """List of providers for dependency injection."""
     imports: list[ModuleType | DynamicModule] = field(default_factory=list)
     """List of modules imported by this module."""
@@ -61,7 +61,7 @@ class DynamicModule(ModuleMetadata):
 
 def module(
     *,
-    providers: Sequence[Provider] = (),
+    providers: Sequence[BaseProvider] = (),
     imports: Sequence[ModuleType | DynamicModule] = (),
     exports: Sequence[object | ModuleType | DynamicModule] = (),
     extensions: Sequence[ModuleExtension] = (),

--- a/src/waku/modules/_module.py
+++ b/src/waku/modules/_module.py
@@ -1,14 +1,13 @@
-from __future__ import annotations  # noqa: I001
+from __future__ import annotations
 
 import sys
 from typing import TYPE_CHECKING, Final
-
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from uuid import UUID
 
-    from dishka import Provider
+    from dishka.provider import BaseProvider
 
     from waku.extensions import ModuleExtension
     from waku.modules._metadata import DynamicModule, ModuleMetadata, ModuleType
@@ -20,7 +19,7 @@ class Module:
         self.target: Final[ModuleType] = module_type
         self.distance: Final[int] = sys.maxsize if metadata.is_global else 0
 
-        self.providers: Final[Sequence[Provider]] = metadata.providers
+        self.providers: Final[Sequence[BaseProvider]] = metadata.providers
         self.imports: Final[Sequence[ModuleType | DynamicModule]] = metadata.imports
         self.exports: Final[Sequence[object | ModuleType]] = metadata.exports
         self.extensions: Final[Sequence[ModuleExtension]] = metadata.extensions

--- a/src/waku/testing.py
+++ b/src/waku/testing.py
@@ -1,0 +1,37 @@
+import contextlib
+from collections.abc import Iterator
+
+from dishka import DEFAULT_COMPONENT, make_async_container
+from dishka.provider import BaseProvider
+
+from waku.di import AsyncContainer
+
+
+def _container_provider(container: AsyncContainer) -> BaseProvider:
+    container_provider = BaseProvider(component=DEFAULT_COMPONENT)
+    container_provider.factories.extend(container.registry.factories.values())
+    for registry in container.child_registries:
+        container_provider.factories.extend(registry.factories.values())
+    return container_provider
+
+
+def _swap(c1: AsyncContainer, c2: AsyncContainer) -> None:
+    for attr in type(c1).__slots__:
+        tmp = getattr(c1, attr)
+        setattr(c1, attr, getattr(c2, attr))
+        setattr(c2, attr, tmp)
+
+
+@contextlib.contextmanager
+def override(
+    container: AsyncContainer,
+    *providers: BaseProvider,
+) -> Iterator[None]:
+    new_container = make_async_container(
+        _container_provider(container),
+        *providers,
+        context=container._context,  # noqa: SLF001
+    )
+    _swap(container, new_container)
+    yield
+    _swap(new_container, container)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
+from typing import Any, cast
+
 import pytest
 
-pytest_plugins = [
-    'anyio',
-]
 
-
-@pytest.fixture(scope='session', autouse=True)
-def anyio_backend() -> str:
-    return 'asyncio'
+@pytest.fixture(
+    params=[
+        pytest.param(('asyncio', {'use_uvloop': True}), id='asyncio+uvloop'),
+        pytest.param(('asyncio', {'use_uvloop': False}), id='asyncio'),
+        pytest.param(('trio', {'restrict_keyboard_interrupt_to_checkpoints': True}), id='trio'),
+    ],
+    autouse=True,
+)
+def anyio_backend(request: pytest.FixtureRequest) -> tuple[str, dict[str, Any]]:
+    return cast(tuple[str, dict[str, Any]], request.param)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from dishka import Scope
-
 from waku import WakuApplication, WakuFactory
-from waku.di import provider
+from waku.di import scoped, singleton
 from waku.modules import module
 
 if TYPE_CHECKING:
@@ -58,11 +56,11 @@ async def test_application_module_registration() -> None:
     class ServiceB:
         pass
 
-    @module(providers=[provider(ServiceA)], exports=[ServiceA])
+    @module(providers=[scoped(ServiceA)], exports=[ServiceA])
     class ModuleA:
         pass
 
-    @module(providers=[provider(ServiceB, scope=Scope.APP)], imports=[ModuleA])
+    @module(providers=[singleton(ServiceB)], imports=[ModuleA])
     class ModuleB:
         pass
 

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from waku import WakuFactory, module
+from waku.di import (
+    contextual,
+    object_,
+    scoped,
+    singleton,
+    transient,
+)
+
+
+@dataclass
+class Service:
+    value: int = 1
+
+
+@dataclass
+class DependentService:
+    service: Service
+
+
+@dataclass
+class RequestContext:
+    user_id: int
+
+
+@dataclass
+class UserService:
+    user_id: int
+
+
+def create_user_service(ctx: RequestContext) -> UserService:
+    return UserService(ctx.user_id)
+
+
+async def test_provider_scopes() -> None:
+    @module(
+        providers=[
+            scoped(DependentService),
+            transient(lambda: Service(value=2), provided_type=Service),
+        ]
+    )
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app, app.container() as container:
+        # Test transient - new instance each time
+        service1 = await container.get(Service)
+        service2 = await container.get(Service)
+        assert service1 is not service2
+        assert service1.value == 2
+        assert service2.value == 2
+
+        # Test scoped - same instance per request
+        dep1 = await container.get(DependentService)
+        dep2 = await container.get(DependentService)
+        assert dep1 is dep2
+
+
+async def test_object_provider() -> None:
+    service = Service(value=3)
+
+    @module(providers=[object_(service, provided_type=Service)])
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app, app.container() as container:
+        result = await container.get(Service)
+        assert result is service
+        assert result.value == 3
+
+
+async def test_contextual_provider() -> None:
+    service_instance = Service(value=4)
+
+    @module(providers=[contextual(Service)])
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app:
+        context = {Service: service_instance}
+        async with app.container(context=context) as container:
+            result = await container.get(Service)
+            assert result is service_instance
+            assert result.value == 4
+
+
+async def test_request_context_provider() -> None:
+    @module(
+        providers=[
+            contextual(RequestContext),
+            scoped(create_user_service, provided_type=UserService),
+        ]
+    )
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app:
+        # First request
+        context1 = {RequestContext: RequestContext(user_id=1)}
+        async with app.container(context=context1) as container1:
+            user1 = await container1.get(UserService)
+            assert user1.user_id == 1
+
+        # Second request with different context
+        context2 = {RequestContext: RequestContext(user_id=2)}
+        async with app.container(context=context2) as container2:
+            user2 = await container2.get(UserService)
+            assert user2.user_id == 2
+
+
+async def test_provider_with_type() -> None:
+    class BaseService:
+        pass
+
+    class ConcreteService(BaseService):
+        pass
+
+    @module(providers=[scoped(ConcreteService, provided_type=BaseService)])
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app, app.container() as container:
+        result = await container.get(BaseService)
+        assert isinstance(result, ConcreteService)
+
+
+async def test_injected_dependency() -> None:
+    @module(
+        providers=[
+            singleton(lambda: 1, provided_type=int),
+            scoped(Service),
+            scoped(DependentService),
+        ]
+    )
+    class AppModule:
+        pass
+
+    app = WakuFactory(AppModule).create()
+
+    async with app, app.container() as container:
+        service = await container.get(Service)
+        dep = await container.get(DependentService)
+        assert dep.service is service

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,44 @@
+from dishka import Scope
+
+from waku import WakuFactory, module
+from waku.di import contextual, scoped
+from waku.testing import override
+
+
+class Service:
+    def __init__(self, val: int) -> None:
+        self.val = val
+
+    def method(self) -> int:
+        return self.val
+
+
+class ServiceOverride(Service):
+    def method(self) -> int:  # noqa: PLR6301
+        return 42
+
+
+async def test_override_helper() -> None:
+    @module(
+        providers=[
+            contextual(int, scope=Scope.APP),
+            scoped(Service),
+        ]
+    )
+    class AppModule:
+        pass
+
+    val = 1
+    application = WakuFactory(AppModule, context={int: val}).create()
+
+    async with application:
+        async with application.container() as request_container:
+            original_service = await request_container.get(Service)
+            assert isinstance(original_service, Service)
+            assert original_service.method() == val
+
+        with override(application.container, scoped(ServiceOverride, provided_type=Service)):
+            async with application.container() as request_container:
+                overrode_service = await request_container.get(Service)
+                assert isinstance(overrode_service, ServiceOverride)
+                assert overrode_service.method() == 42

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload_time = "2025-03-13T11:10:22.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload_time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -96,6 +105,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload_time = "2025-01-31T02:16:47.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload_time = "2025-01-31T02:16:45.015Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload_time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727, upload_time = "2024-09-04T20:44:09.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400, upload_time = "2024-09-04T20:44:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload_time = "2024-09-04T20:44:26.208Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload_time = "2024-09-04T20:44:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload_time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload_time = "2024-09-04T20:44:45.309Z" },
 ]
 
 [[package]]
@@ -797,6 +823,18 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload_time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload_time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -939,6 +977,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/75/813967eae0542776314c6def33feac687642a193b9d5591c20684b2eafd8/py_serializable-2.0.0.tar.gz", hash = "sha256:e9e6491dd7d29c31daf1050232b57f9657f9e8a43b867cca1ff204752cf420a5", size = 51617, upload_time = "2025-02-09T13:41:55.768Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/0e/8601d2331dea0825f3be769688b48a95f387a83c918cca6a8c9cee4b9eb7/py_serializable-2.0.0-py3-none-any.whl", hash = "sha256:1721e4c0368adeec965c183168da4b912024702f19e15e13f8577098b9a4f8fe", size = 22824, upload_time = "2025-02-09T13:41:54.236Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload_time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload_time = "2024-03-30T13:22:20.476Z" },
 ]
 
 [[package]]
@@ -1293,6 +1340,23 @@ wheels = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/c1/68d582b4d3a1c1f8118e18042464bb12a7c1b75d64d75111b297687041e3/trio-0.30.0.tar.gz", hash = "sha256:0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df", size = 593776, upload_time = "2025-04-21T00:48:19.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/8e/3f6dfda475ecd940e786defe6df6c500734e686c9cd0a0f8ef6821e9b2f2/trio-0.30.0-py3-none-any.whl", hash = "sha256:3bf4f06b8decf8d3cf00af85f40a89824669e2d033bb32469d34840edcfc22a5", size = 499194, upload_time = "2025-04-21T00:48:17.167Z" },
+]
+
+[[package]]
 name = "types-setuptools"
 version = "79.0.0.20250422"
 source = { registry = "https://pypi.org/simple" }
@@ -1323,6 +1387,32 @@ wheels = [
 ]
 
 [[package]]
+name = "uvloop"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/c0/854216d09d33c543f12a44b393c402e89a920b1a0a7dc634c42de91b9cf6/uvloop-0.21.0.tar.gz", hash = "sha256:3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3", size = 2492741, upload_time = "2024-10-14T23:38:35.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/4cf0334105c1160dd6819f3297f8700fda7fc30ab4f61fbf3e725acbc7cc/uvloop-0.21.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0f3fa6200b3108919f8bdabb9a7f87f20e7097ea3c543754cabc7d717d95cf8", size = 1447410, upload_time = "2024-10-14T23:37:33.612Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7c/1517b0bbc2dbe784b563d6ab54f2ef88c890fdad77232c98ed490aa07132/uvloop-0.21.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0", size = 805476, upload_time = "2024-10-14T23:37:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ea/0bfae1aceb82a503f358d8d2fa126ca9dbdb2ba9c7866974faec1cb5875c/uvloop-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9fb766bb57b7388745d8bcc53a359b116b8a04c83a2288069809d2b3466c37e", size = 3960855, upload_time = "2024-10-14T23:37:37.683Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ca/0864176a649838b838f36d44bf31c451597ab363b60dc9e09c9630619d41/uvloop-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a375441696e2eda1c43c44ccb66e04d61ceeffcd76e4929e527b7fa401b90fb", size = 3973185, upload_time = "2024-10-14T23:37:40.226Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bf/08ad29979a936d63787ba47a540de2132169f140d54aa25bc8c3df3e67f4/uvloop-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:baa0e6291d91649c6ba4ed4b2f982f9fa165b5bbd50a9e203c416a2797bab3c6", size = 3820256, upload_time = "2024-10-14T23:37:42.839Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e2/5cf6ef37e3daf2f06e651aae5ea108ad30df3cb269102678b61ebf1fdf42/uvloop-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4509360fcc4c3bd2c70d87573ad472de40c13387f5fda8cb58350a1d7475e58d", size = 3937323, upload_time = "2024-10-14T23:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4c/03f93178830dc7ce8b4cdee1d36770d2f5ebb6f3d37d354e061eefc73545/uvloop-0.21.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:359ec2c888397b9e592a889c4d72ba3d6befba8b2bb01743f72fffbde663b59c", size = 1471284, upload_time = "2024-10-14T23:37:47.833Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3e/92c03f4d05e50f09251bd8b2b2b584a2a7f8fe600008bcc4523337abe676/uvloop-0.21.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7089d2dc73179ce5ac255bdf37c236a9f914b264825fdaacaded6990a7fb4c2", size = 821349, upload_time = "2024-10-14T23:37:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ef/a02ec5da49909dbbfb1fd205a9a1ac4e88ea92dcae885e7c961847cd51e2/uvloop-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa4dcdbd9ae0a372f2167a207cd98c9f9a1ea1188a8a526431eef2f8116cc8d", size = 4580089, upload_time = "2024-10-14T23:37:51.703Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a7/b4e6a19925c900be9f98bec0a75e6e8f79bb53bdeb891916609ab3958967/uvloop-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86975dca1c773a2c9864f4c52c5a55631038e387b47eaf56210f873887b6c8dc", size = 4693770, upload_time = "2024-10-14T23:37:54.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/f07435a18a4b94ce6bd0677d8319cd3de61f3a9eeb1e5f8ab4e8b5edfcb3/uvloop-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:461d9ae6660fbbafedd07559c6a2e57cd553b34b0065b6550685f6653a98c1cb", size = 4451321, upload_time = "2024-10-14T23:37:55.766Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/f7032be105877bcf924709c97b1bf3b90255b4ec251f9340cef912559f28/uvloop-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:183aef7c8730e54c9a3ee3227464daed66e37ba13040bb3f350bc2ddc040f22f", size = 4659022, upload_time = "2024-10-14T23:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8d/2cbef610ca21539f0f36e2b34da49302029e7c9f09acef0b1c3b5839412b/uvloop-0.21.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bfd55dfcc2a512316e65f16e503e9e450cab148ef11df4e4e679b5e8253a5281", size = 1468123, upload_time = "2024-10-14T23:38:00.688Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0d/b0038d5a469f94ed8f2b2fce2434a18396d8fbfb5da85a0a9781ebbdec14/uvloop-0.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787ae31ad8a2856fc4e7c095341cccc7209bd657d0e71ad0dc2ea83c4a6fa8af", size = 819325, upload_time = "2024-10-14T23:38:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/0a687f39e78c4c1e02e3272c6b2ccdb4e0085fda3b8352fecd0410ccf915/uvloop-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ee4d4ef48036ff6e5cfffb09dd192c7a5027153948d85b8da7ff705065bacc6", size = 4582806, upload_time = "2024-10-14T23:38:04.711Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload_time = "2024-10-14T23:38:06.385Z" },
+    { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload_time = "2024-10-14T23:38:08.416Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload_time = "2024-10-14T23:38:10.888Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1341,6 +1431,7 @@ name = "waku"
 version = "0.8.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "dishka" },
     { name = "typing-extensions" },
 ]
@@ -1367,7 +1458,6 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "anyio" },
     { name = "pytest" },
     { name = "pytest-archon" },
     { name = "pytest-clarity" },
@@ -1375,6 +1465,8 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-timeout" },
+    { name = "trio" },
+    { name = "uvloop" },
 ]
 typecheck = [
     { name = "basedpyright" },
@@ -1384,6 +1476,7 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio" },
     { name = "dishka", specifier = ">=1.5.3" },
     { name = "typing-extensions", specifier = ">=4.12" },
 ]
@@ -1410,7 +1503,6 @@ lint = [
     { name = "ruff", specifier = ">=0.11.2" },
 ]
 test = [
-    { name = "anyio", specifier = ">=4.9.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-archon", specifier = ">=0.0.6" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
@@ -1418,6 +1510,8 @@ test = [
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "trio", specifier = ">=0.30.0" },
+    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.28.3" },


### PR DESCRIPTION
## Summary by Sourcery

Add dependency injection helpers and testing utilities to improve the Waku framework's dependency injection and testing capabilities

New Features:
- Introduce new DI helper functions like singleton(), scoped(), transient(), object_(), and contextual()
- Add a testing override helper to simplify dependency injection testing
- Extend AsyncContainer exports and imports

Enhancements:
- Simplify provider creation with new helper functions
- Improve dependency injection flexibility
- Update examples and tests to use new DI helpers

Tests:
- Add comprehensive tests for new DI helpers
- Add tests for contextual and override providers
- Enhance testing configuration with multiple backend support

Chores:
- Replace asyncio TaskGroup with anyio's create_task_group
- Update dependencies and testing configuration