### PR TITLE
fix(validation): fix check for provided types in the current module without explicit export

### DIFF
--- a/gitlint_plugins.py
+++ b/gitlint_plugins.py
@@ -36,6 +36,7 @@ class ConventionalCommitTitle(LineRule):  # type: ignore[misc]
         'mediator',
         'release',
         'tests',
+        'validation',
     )
     default_types: ClassVar[tuple[str, ...]] = (
         'build',

--- a/src/waku/ext/validation/_errors.py
+++ b/src/waku/ext/validation/_errors.py
@@ -1,5 +1,7 @@
+from waku.exceptions import WakuError
+
 __all__ = ['ValidationError']
 
 
-class ValidationError(Exception):
+class ValidationError(WakuError):
     pass

--- a/src/waku/ext/validation/rules.py
+++ b/src/waku/ext/validation/rules.py
@@ -79,19 +79,14 @@ def _can_access_dependency(
     # 1. Dep available globally
     if dep_type in global_providers:
         return True
-    # 2. Dep exported by current module
-    if _is_type_exported_by_module(dep_type, module):
+    # 2. Dep provided by current module (regardless of export)
+    if dep_type in _module_provided_types(module):
         return True
     # 3. Dep extracted from container context
     if dep_type in _module_provided_context_vars(module):
         return True
-    # 4. Dep provided by any of imported modules
-    # fmt: off
-    return any(
-        _is_type_exported_by_module(dep_type, imported_module)
-        for imported_module in imported_modules
-    )
-    # fmt: on
+    # 4. Dep provided by any of imported modules (must be exported)
+    return any(_is_type_exported_by_module(dep_type, imported_module) for imported_module in imported_modules)
 
 
 @functools.cache

--- a/tests/validation/test_dependencies_accessible.py
+++ b/tests/validation/test_dependencies_accessible.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import NewType, Protocol
+from typing import NewType, Protocol, cast
 
 import pytest
 
 from waku import WakuApplication, WakuFactory
 from waku.di import Scope, contextual, scoped
-from waku.ext.validation import ValidationExtension, ValidationRule
+from waku.ext.validation import ValidationError, ValidationExtension, ValidationRule
 from waku.ext.validation.rules import DependenciesAccessible
 from waku.modules import ModuleType, module
 
@@ -41,34 +41,49 @@ def rule() -> ValidationRule:
 
 
 class ApplicationFactoryFunc(Protocol):
-    def __call__(self, root_module: ModuleType) -> WakuApplication: ...
+    def __call__(
+        self,
+        root_module: ModuleType,
+        *,
+        strict: bool = True,
+        context: dict[type, object] | None = None,
+    ) -> WakuApplication: ...
 
 
 @pytest.fixture
 def application_factory(rule: ValidationRule) -> ApplicationFactoryFunc:
-    def factory(root_module: ModuleType) -> WakuApplication:
+    def factory(
+        root_module: ModuleType,
+        *,
+        strict: bool = True,
+        context: dict[type, object] | None = None,
+    ) -> WakuApplication:
         return WakuFactory(
             root_module,
-            extensions=[ValidationExtension([rule])],
+            context=context or {},
+            extensions=[ValidationExtension([rule], strict=strict)],
         ).create()
 
     return factory
 
 
 @pytest.mark.parametrize(
-    ('imports', 'exports'),
+    ('imports', 'exports', 'should_fail'),
     [
-        (False, False),
-        (False, True),
-        (True, False),
+        (False, False, True),
+        (False, True, True),
+        (True, False, True),
+        (True, True, False),
     ],
 )
-async def test_inaccessible(
+async def test_accessibility_import_export_matrix(
     imports: bool,
     exports: bool,
-    rule: ValidationRule,
+    should_fail: bool,
     application_factory: ApplicationFactoryFunc,
 ) -> None:
+    """Test all combinations of import/export for dependency accessibility."""
+
     @module(providers=[scoped(A)], exports=[A] if exports else [])
     class AModule:
         pass
@@ -82,24 +97,20 @@ async def test_inaccessible(
         pass
 
     application = application_factory(AppModule)
-
-    with pytest.raises(ExceptionGroup) as exc_info:
-        await application.initialize()
-
-    error = exc_info.value.exceptions[0].exceptions[0]
-    b_module = application.registry.get(BModule)
-    error_message = f'"{B!r}" from "{b_module!r}" depends on "{A!r}" but it\'s not accessible to it'
-    assert str(error).startswith(error_message)
-
-    application = WakuFactory(
-        AppModule,
-        extensions=[ValidationExtension([rule], strict=False)],
-    ).create()
-    with pytest.warns(Warning, match=re.escape(error_message)):
+    if should_fail:
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await application.initialize()
+        b_module = application.registry.get(BModule)
+        error_message = f'"{B!r}" from "{b_module!r}" depends on "{A!r}" but it\'s not accessible to it'
+        error = cast(ValidationError, exc_info.value.exceptions[0].exceptions[0])
+        assert str(error).startswith(error_message)
+    else:
         await application.initialize()
 
 
-async def test_ok(application_factory: ApplicationFactoryFunc) -> None:
+async def test_accessible_with_exported_and_imported(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that dependency is accessible when exported and imported."""
+
     @module(providers=[scoped(A), scoped(_impl, provided_type=C)], exports=[A, C])
     class AModule:
         pass
@@ -112,11 +123,12 @@ async def test_ok(application_factory: ApplicationFactoryFunc) -> None:
     class AppModule:
         pass
 
-    application = application_factory(AppModule)
-    await application.initialize()
+    await application_factory(AppModule).initialize()
 
 
-async def test_ok_with_global_providers(application_factory: ApplicationFactoryFunc) -> None:
+async def test_accessible_with_global_provider(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that global providers are accessible everywhere."""
+
     @module(providers=[scoped(A)], is_global=True)
     class AModule:
         pass
@@ -129,12 +141,16 @@ async def test_ok_with_global_providers(application_factory: ApplicationFactoryF
     class AppModule:
         pass
 
-    application = application_factory(AppModule)
-    await application.initialize()
+    await application_factory(AppModule).initialize()
 
 
 @pytest.mark.parametrize('scope', [Scope.APP, Scope.REQUEST])
-async def test_with_contextual_provider(rule: ValidationRule, scope: Scope) -> None:
+async def test_accessible_with_contextual_provider(
+    rule: ValidationRule,
+    scope: Scope,
+) -> None:
+    """Test that contextual providers are accessible if present in context."""
+
     @module(
         providers=[
             contextual(A, scope=scope),
@@ -154,11 +170,12 @@ async def test_with_contextual_provider(rule: ValidationRule, scope: Scope) -> N
         context={A: A()},
         extensions=[ValidationExtension([rule])],
     ).create()
-
     await application.initialize()
 
 
-async def test_ok_with_application_providers(application_factory: ApplicationFactoryFunc) -> None:
+async def test_accessible_with_application_providers(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that providers in the application module are accessible."""
+
     @module(providers=[scoped(B)], exports=[B])
     class BModule:
         pass
@@ -167,5 +184,82 @@ async def test_ok_with_application_providers(application_factory: ApplicationFac
     class AppModule:
         pass
 
-    application = application_factory(AppModule)
+    application: WakuApplication = application_factory(AppModule)
     await application.initialize()
+
+
+async def test_intra_module_access(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that providers can access each other within the same module without export."""
+
+    @module(providers=[scoped(A), scoped(B)])
+    class Module:
+        pass
+
+    @module(imports=[Module])
+    class AppModule:
+        pass
+
+    await application_factory(AppModule).initialize()
+
+
+@dataclass
+class X:
+    pass
+
+
+@dataclass
+class Y:
+    pass
+
+
+@dataclass
+class Z:
+    x: X
+    y: Y
+
+
+async def test_multiple_missing_dependencies(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that multiple missing dependencies are all reported."""
+
+    @module(providers=[scoped(X), scoped(Y)])
+    class XYModule:
+        pass
+
+    @module(providers=[scoped(Z)])
+    class ZModule:
+        pass
+
+    @module(imports=[XYModule, ZModule])
+    class AppModule:
+        pass
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await application_factory(AppModule).initialize()
+
+    validation_errors = exc_info.value.exceptions[0].exceptions
+    error_msgs = [str(e) for e in validation_errors]
+    assert any('depends on' in msg and 'X' in msg for msg in error_msgs)
+    assert any('depends on' in msg and 'Y' in msg for msg in error_msgs)
+
+
+async def test_warning_mode(application_factory: ApplicationFactoryFunc) -> None:
+    """Test that non-strict mode emits warnings instead of raising."""
+
+    @module(providers=[scoped(A)])
+    class AModule:
+        pass
+
+    @module(providers=[scoped(B)], imports=[])  # No import, should warn
+    class BModule:
+        pass
+
+    @module(imports=[AModule, BModule])
+    class AppModule:
+        pass
+
+    application = application_factory(AppModule, strict=False)
+
+    b_module = application.registry.get(BModule)
+    error_message = f'"{B!r}" from "{b_module!r}" depends on "{A!r}" but it\'s not accessible to it'
+    with pytest.warns(Warning, match=re.escape(error_message)):
+        await application.initialize()


### PR DESCRIPTION
## Summary by Sourcery

Correct the dependency accessibility validation rule to allow providers within the same module to access each other without requiring explicit exports. Dependencies accessed from imported modules still need to be exported.

Bug Fixes:
- Fix validation rule to correctly identify dependencies provided within the same module as accessible, regardless of export status

Enhancements:
- Update `ValidationError` to inherit from the base `WakuError`

Tests:
- Refactor and expand tests for dependency accessibility validation.
- Add tests specifically for intra-module dependency access.
- Add tests for reporting multiple missing dependencies.
- Add tests for the non-strict (warning) validation mode.

Chores:
- Add 'validation' to the list of allowed commit scopes in gitlint configuration