### PR TITLE
feat(core): make module traversal post-order dfs

### DIFF
--- a/src/waku/ext/validation/rules.py
+++ b/src/waku/ext/validation/rules.py
@@ -30,7 +30,7 @@ class DependenciesAccessible(ValidationRule):
     @override
     def validate(self, context: ValidationContext) -> list[ValidationError]:
         registry: ModuleRegistry = context.app.registry
-        modules: list[Module] = list(registry.traverse())  # Cache traversal results
+        modules: list[Module] = list(registry.traverse())  # Validate all registered modules
 
         # Cache global providers
         global_providers: set[type[object]] = {AsyncContainer}
@@ -49,7 +49,7 @@ class DependenciesAccessible(ValidationRule):
 
         errors: list[ValidationError] = []
         for module in modules:
-            imported_modules = list(registry.traverse(module))
+            imported_modules = [m for m in registry.traverse(module) if m != module]
             for provider in module.providers:
                 for factory in provider.factories:
                     inaccessible_deps: set[type[object]] = set()


### PR DESCRIPTION
## Summary by Sourcery

Modify module graph processing to use post-order Depth-First Search (DFS).

Enhancements:
- Register modules in post-order DFS sequence, ensuring dependencies are processed first.
- Update the `ModuleRegistry.traverse` method to iterate modules in post-order DFS.
- Adjust dependency validation logic to align with the new traversal order.
- Preserve module import order in the internal dependency graph representation.