### PR TITLE
feat(core): group all module providers within one dishka provider

### DIFF
--- a/src/waku/di.py
+++ b/src/waku/di.py
@@ -4,6 +4,7 @@ from typing import Any
 from dishka import (
     AnyOf,
     AsyncContainer,
+    FromComponent,
     FromDishka as Injected,
     Provider,
     Scope,
@@ -19,6 +20,7 @@ __all__ = [
     'AnyOf',
     'AsyncContainer',
     'BaseProvider',
+    'FromComponent',
     'Injected',
     'Provider',
     'Scope',

--- a/src/waku/ext/validation/rules/_types_extractor.py
+++ b/src/waku/ext/validation/rules/_types_extractor.py
@@ -26,10 +26,10 @@ class ModuleTypesExtractor:
         if cached is not None:
             return cached
 
+        module_provider = module.provider
         result: set[type[object]] = {
             cast(_HasProvidesAttr, dep).provides.type_hint
-            for provider in module.providers
-            for dep in chain(provider.factories, provider.aliases, provider.decorators)
+            for dep in chain(module_provider.factories, module_provider.aliases, module_provider.decorators)
         }
         self._cache.put(cache_key, result)
         return result
@@ -40,9 +40,7 @@ class ModuleTypesExtractor:
         if cached is not None:
             return cached
 
-        result: set[type[object]] = {
-            context_var.provides.type_hint for provider in module.providers for context_var in provider.context_vars
-        }
+        result: set[type[object]] = {context_var.provides.type_hint for context_var in module.provider.context_vars}
         self._cache.put(cache_key, result)
         return result
 

--- a/src/waku/ext/validation/rules/dependency_accessible.py
+++ b/src/waku/ext/validation/rules/dependency_accessible.py
@@ -156,19 +156,19 @@ class DependenciesAccessibleRule(ValidationRule):
         errors: list[ValidationError] = []
 
         for module in modules:
-            for provider in module.providers:
-                for factory in provider.factories:
-                    inaccessible_deps = checker.find_inaccessible_dependencies(
-                        dependencies=factory.dependencies,
-                        module=module,
+            module_provider = module.provider
+            for factory in module_provider.factories:
+                inaccessible_deps = checker.find_inaccessible_dependencies(
+                    dependencies=factory.dependencies,
+                    module=module,
+                )
+                errors.extend(
+                    DependencyInaccessibleError(
+                        required_type=dep_type,
+                        required_by=factory.source,
+                        from_module=module,
                     )
-                    errors.extend(
-                        DependencyInaccessibleError(
-                            required_type=dep_type,
-                            required_by=factory.source,
-                            from_module=module,
-                        )
-                        for dep_type in inaccessible_deps
-                    )
+                    for dep_type in inaccessible_deps
+                )
 
         return errors

--- a/src/waku/modules/_registry_builder.py
+++ b/src/waku/modules/_registry_builder.py
@@ -7,9 +7,8 @@ from uuid import UUID
 from waku.modules import Module, ModuleCompiler, ModuleMetadata, ModuleRegistry, ModuleType
 
 if TYPE_CHECKING:
-    from dishka.provider import BaseProvider
-
     from waku import DynamicModule
+    from waku.di import BaseProvider
     from waku.extensions import ModuleExtension
 
 
@@ -78,7 +77,7 @@ class ModuleRegistryBuilder:
             module = Module(type_, metadata)
 
             self._modules[module.id] = module
-            self._providers.extend(module.providers)
+            self._providers.append(module.provider)
 
         _, root_metadata = self._get_metadata(self._root_module_type)
         return self._modules[root_metadata.id]

--- a/tests/data.py
+++ b/tests/data.py
@@ -3,9 +3,8 @@
 from dataclasses import dataclass
 from typing import NewType
 
-from dishka.provider import BaseProvider
-
 from waku import Module
+from waku.di import BaseProvider
 from waku.extensions import OnModuleConfigure, OnModuleDestroy, OnModuleInit
 from waku.modules import ModuleMetadata
 


### PR DESCRIPTION
Resolves #147

## Summary by Sourcery

Refactor module providers to be grouped within a single Dishka provider for each module

New Features:
- Introduced a new _ModuleProvider class that consolidates multiple providers into a single provider for a module

Enhancements:
- Added a cached_property to create a unified provider for each module
- Simplified provider handling across multiple validation and registry methods