### PR TITLE
ci: fix codecov upload

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,7 +194,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup | Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -225,7 +225,6 @@ jobs:
             --timeout=${{ env.PYTEST_TIMEOUT }} \
             --cov-append \
             --junit-xml=tests/reports/pytest-results-${{ matrix.python-version }}.xml \
-            --cov-report=xml:tests/reports/coverage-${{ matrix.python-version }}.xml
 
       - name: Test | Archive JUnit XML test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -235,12 +234,16 @@ jobs:
           if-no-files-found: error
           retention-days: 2
 
+      - name: Test | Rename coverage file
+        run: mv .coverage .coverage.${{ matrix.python-version }}
+
       - name: Test | Archive coverage results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report-${{ matrix.python-version }}
-          path: tests/reports/coverage-${{ matrix.python-version }}.xml
+          path: .coverage.${{ matrix.python-version }}
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 2
 
   upload-test-results:
@@ -248,6 +251,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - name: Setup | Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Setup | Install Python ${{ env.COMMON_PYTHON_VERSION }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.COMMON_PYTHON_VERSION }}
+          check-latest: true
+
+      - name: Setup | Install UV
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        with:
+          enable-cache: true
+
       - name: Report | Download test results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -264,9 +284,14 @@ jobs:
       - name: Report | Download coverage reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          pattern: coverage-*
+          pattern: coverage-report-*
           path: ./tests/reports/
           merge-multiple: true
+
+      - name: Report | Combine coverage reports
+        run: |
+          uvx coverage combine --append tests/reports
+          uvx coverage xml -o tests/reports/coverage-combined.xml
 
       - name: Report | Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
@@ -274,7 +299,7 @@ jobs:
           disable_search: true
           directory: ./tests/reports/
           fail_ci_if_error: true
-          files: ./tests/reports/coverage-${{ env.COMMON_PYTHON_VERSION }}.xml
+          files: ./tests/reports/coverage-combined.xml
           slug: waku-py/waku
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set fetch-depth to 0 on the initial test checkout and added a full-depth checkout before reporting to retrieve the entire repository history for Codecov.