### PR TITLE
ci: upload junit reports to codecov

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -281,6 +281,14 @@ jobs:
           report_paths: ./tests/reports/pytest-results-*.xml
           annotate_only: true
 
+      - name: Report | Upload test results to Codecov
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
+        with:
+          directory: ./tests/reports/
+          env_vars: PYTHON
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Report | Download coverage reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -300,6 +308,4 @@ jobs:
           directory: ./tests/reports/
           fail_ci_if_error: true
           files: ./tests/reports/coverage-combined.xml
-          slug: waku-py/waku
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true


### PR DESCRIPTION
## Summary by Sourcery

Add a CI step to upload JUnit test results to Codecov and simplify the coverage report download by removing the explicit slug setting

CI:
- Introduce a GitHub Action to report and upload pytest XML results to Codecov
- Remove the hardcoded repository slug from the Codecov coverage download step