### PR TITLE
feat(tests): allow to override not only application container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,17 @@ ban-relative-imports = "all"
 [tool.ruff.lint.isort]
 force-wrap-aliases = true
 combine-as-imports = true
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "first-party",
+  "tests",
+  "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+tests = ["tests"]
 
 [tool.ruff.format]
 preview = true

--- a/src/waku/testing.py
+++ b/src/waku/testing.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from dishka import DEFAULT_COMPONENT, make_async_container
+from dishka import make_async_container
 
-from waku.di import BaseProvider
+from waku.di import DEFAULT_COMPONENT, BaseProvider
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -48,6 +48,7 @@ def override(container: AsyncContainer, *providers: BaseProvider) -> Iterator[No
         _container_provider(container),
         *providers,
         context=container._context,  # noqa: SLF001
+        start_scope=container.scope,
     )
     _swap(container, new_container)
     yield

--- a/tests/application/test_lifecycle.py
+++ b/tests/application/test_lifecycle.py
@@ -2,8 +2,9 @@
 
 from dataclasses import dataclass
 
-from tests.module_utils import create_basic_module
 from waku import WakuFactory
+
+from tests.module_utils import create_basic_module
 
 
 @dataclass

--- a/tests/application/test_module_registration.py
+++ b/tests/application/test_module_registration.py
@@ -1,7 +1,8 @@
-from tests.data import A, C
-from tests.module_utils import create_basic_module
 from waku import WakuFactory
 from waku.di import scoped, singleton
+
+from tests.data import A, C
+from tests.module_utils import create_basic_module
 
 
 async def test_module_registration_with_dependencies() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 
 @pytest.fixture(
+    scope='session',
     params=[
         pytest.param(
             ('asyncio', {'use_uvloop': True}),

--- a/tests/di/test_providers.py
+++ b/tests/di/test_providers.py
@@ -1,9 +1,10 @@
 from typing import Protocol
 
-from tests.data import UserService
-from tests.module_utils import create_basic_module
 from waku import WakuFactory
 from waku.di import object_, scoped
+
+from tests.data import UserService
+from tests.module_utils import create_basic_module
 
 
 async def test_object_provider_instance_identity() -> None:

--- a/tests/di/test_scopes.py
+++ b/tests/di/test_scopes.py
@@ -1,9 +1,10 @@
 """Tests for dependency injection scopes."""
 
-from tests.data import DependentService, RequestContext, Service, UserService
-from tests.module_utils import create_basic_module
 from waku import WakuFactory
 from waku.di import contextual, scoped, singleton, transient
+
+from tests.data import DependentService, RequestContext, Service, UserService
+from tests.module_utils import create_basic_module
 
 
 async def test_provider_scope_behavior() -> None:

--- a/tests/extensions/test_application_extensions.py
+++ b/tests/extensions/test_application_extensions.py
@@ -1,9 +1,10 @@
 from pytest_mock import MockerFixture
 
-from tests.module_utils import create_basic_module
 from waku import WakuApplication, WakuFactory
 from waku.extensions import AfterApplicationInit, OnApplicationInit, OnModuleConfigure, OnModuleInit
 from waku.modules import Module, ModuleMetadata
+
+from tests.module_utils import create_basic_module
 
 
 async def test_module_init_extension_lifecycle(mocker: MockerFixture) -> None:

--- a/tests/extensions/test_module_extensions.py
+++ b/tests/extensions/test_module_extensions.py
@@ -1,9 +1,10 @@
 """Tests for module extensions."""
 
-from tests.data import A, AddDepOnConfigure, OnDestroyExt, OnInitExt
-from tests.module_utils import create_basic_module
 from waku import WakuFactory
 from waku.di import scoped
+
+from tests.data import A, AddDepOnConfigure, OnDestroyExt, OnInitExt
+from tests.module_utils import create_basic_module
 
 
 async def test_module_extensions_initialization_and_destruction_order() -> None:

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tests.module_utils import create_basic_module
 from waku.extensions import (
     AfterApplicationInit,
     OnApplicationInit,
@@ -13,6 +12,8 @@ from waku.extensions import (
     OnModuleInit,
 )
 from waku.extensions.registry import ExtensionRegistry
+
+from tests.module_utils import create_basic_module
 
 if TYPE_CHECKING:
     from waku import WakuApplication

--- a/tests/modules/test_dynamic_modules.py
+++ b/tests/modules/test_dynamic_modules.py
@@ -1,9 +1,10 @@
 """Tests for dynamic module functionality."""
 
-from tests.data import A, AddDepOnConfigure
-from tests.module_utils import create_basic_module, create_dynamic_module
 from waku import WakuFactory
 from waku.di import scoped
+
+from tests.data import A, AddDepOnConfigure
+from tests.module_utils import create_basic_module, create_dynamic_module
 
 
 def test_dynamic_module_configuration() -> None:

--- a/tests/test_testing_overrides.py
+++ b/tests/test_testing_overrides.py
@@ -1,9 +1,28 @@
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
+from typing import Final
+
+import pytest
+
+from waku import WakuApplication, WakuFactory
+from waku.di import AsyncContainer, Provider, Scope, contextual, object_, scoped, singleton, transient
+from waku.testing import override
 
 from tests.module_utils import create_basic_module
-from waku import WakuFactory
-from waku.di import Scope, contextual, scoped
-from waku.testing import override
+
+_EXPECTED_VAL: Final[int] = 42
+
+
+class ISomeService:
+    """Interface for some service implementations."""
+
+
+class SomeService(ISomeService):
+    pass
+
+
+class FakeSomeService(ISomeService):
+    pass
 
 
 @dataclass
@@ -16,10 +35,77 @@ class Service:
 
 class ServiceOverride(Service):
     def method(self) -> int:  # noqa: PLR6301
-        return 42
+        return _EXPECTED_VAL
 
 
-async def test_override_helper() -> None:
+class OtherService:
+    pass
+
+
+class FakeOtherService(OtherService):
+    pass
+
+
+# Test fixtures
+@pytest.fixture(scope='session')
+async def application() -> AsyncIterator[WakuApplication]:
+    AppModule = create_basic_module(
+        providers=[
+            singleton(OtherService),  # app scoped
+            scoped(SomeService, provided_type=ISomeService),  # request scoped
+        ],
+        name='AppModule',
+    )
+
+    application = WakuFactory(AppModule).create()
+
+    async with application:
+        yield application
+
+
+@pytest.fixture
+async def request_container(application: WakuApplication) -> AsyncIterator[AsyncContainer]:
+    async with application.container() as request_container:
+        yield request_container
+
+
+# Test cases
+@pytest.mark.parametrize('provider_type', [transient, scoped, singleton])
+async def test_override_with_factory_providers(provider_type: Callable[..., Provider]) -> None:
+    """Test overriding services using factory providers with different scopes."""
+    AppModule = create_basic_module(
+        providers=[provider_type(SomeService, provided_type=ISomeService)],
+        name='AppModule',
+    )
+
+    application = WakuFactory(AppModule).create()
+
+    async with application:
+        with override(application.container, provider_type(FakeSomeService, provided_type=ISomeService)):
+            async with application.container() as request_container:
+                overrode_service = await request_container.get(ISomeService)
+                assert isinstance(overrode_service, FakeSomeService)
+
+
+@pytest.mark.parametrize('provider_type', [transient, scoped, singleton])
+async def test_override_with_object_provider(provider_type: Callable[..., Provider]) -> None:
+    """Test overriding services using object providers with different scopes."""
+    AppModule = create_basic_module(
+        providers=[provider_type(SomeService, provided_type=ISomeService)],
+        name='AppModule',
+    )
+
+    application = WakuFactory(AppModule).create()
+
+    async with application:
+        with override(application.container, object_(FakeSomeService(), provided_type=ISomeService)):
+            async with application.container() as request_container:
+                overrode_service = await request_container.get(ISomeService)
+                assert isinstance(overrode_service, FakeSomeService)
+
+
+async def test_override_with_contextual_provider() -> None:
+    """Test overriding services that depend on contextual providers."""
     AppModule = create_basic_module(
         providers=[
             contextual(int, scope=Scope.APP),
@@ -28,17 +114,35 @@ async def test_override_helper() -> None:
         name='AppModule',
     )
 
-    val = 1
-    application = WakuFactory(AppModule, context={int: val}).create()
+    initial_val = 1
+    application = WakuFactory(AppModule, context={int: initial_val}).create()
 
     async with application:
         async with application.container() as request_container:
             original_service = await request_container.get(Service)
             assert isinstance(original_service, Service)
-            assert original_service.method() == val
+            assert original_service.method() == initial_val
 
         with override(application.container, scoped(ServiceOverride, provided_type=Service)):
             async with application.container() as request_container:
                 overrode_service = await request_container.get(Service)
                 assert isinstance(overrode_service, ServiceOverride)
-                assert overrode_service.method() == 42
+                assert overrode_service.method() == _EXPECTED_VAL
+
+
+async def test_override_app_container_from_fixture(application: WakuApplication) -> None:
+    """Test overriding app-scoped services using fixture-provided application."""
+    with override(application.container, singleton(FakeOtherService, provided_type=OtherService)):
+        overrode_service = await application.container.get(OtherService)
+        assert isinstance(overrode_service, FakeOtherService)
+
+
+@pytest.mark.parametrize('provider_type', [transient, scoped, singleton])
+async def test_override_request_container_from_fixture(
+    request_container: AsyncContainer,
+    provider_type: Callable[..., Provider],
+) -> None:
+    """Test overriding request-scoped services using fixture-provided container."""
+    with override(request_container, provider_type(FakeSomeService, provided_type=ISomeService)):
+        overrode_service = await request_container.get(ISomeService)
+        assert isinstance(overrode_service, FakeSomeService)

--- a/tests/validation/test_dependencies_accessible.py
+++ b/tests/validation/test_dependencies_accessible.py
@@ -8,13 +8,14 @@ from typing import Protocol, TypeVar, cast
 import pytest
 from dishka.exceptions import ImplicitOverrideDetectedError
 
-from tests.data import A, AAliasType, B, C, DependentService, Service, X, Y, Z
-from tests.module_utils import create_basic_module
 from waku import WakuApplication, WakuFactory
 from waku.di import AnyOf, Provider, Scope, contextual, provide, scoped, singleton
 from waku.modules import ModuleType
 from waku.validation import ValidationExtension, ValidationRule
 from waku.validation.rules import DependenciesAccessibleRule, DependencyInaccessibleError
+
+from tests.data import A, AAliasType, B, C, DependentService, Service, X, Y, Z
+from tests.module_utils import create_basic_module
 
 _T_co = TypeVar('_T_co', covariant=True)
 


### PR DESCRIPTION
Also sort imports in tests

## Summary by Sourcery

Extend the override context manager to preserve container scopes and allow service overrides on both application and request containers across factory, object, and contextual providers.

New Features:
- Add `start_scope` parameter to the `override` helper to maintain correct container scope when creating a new async container
- Enable overriding services in request-scoped containers and for factory, object, and contextual providers

Enhancements:
- Refactor import ordering in the override implementation (`src/waku/testing.py`) to include `DEFAULT_COMPONENT` and `BaseProvider`

Build:
- Update `isort` configuration to add a dedicated `tests` import section and adjust section ordering

Tests:
- Add and sort comprehensive tests for override functionality with transient, scoped, singleton, object, and contextual providers
- Introduce fixtures for application and request containers and parametrize tests across provider types
- Sort imports and set session scope for relevant test fixtures