### PR TITLE
build: add python 3.14.0rc1 to testing suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
     needs: eval-changes
     with:
-      python-versions: '[ "3.11", "3.12", "3.13"]'
+      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.1"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
       ci-files-changed: ${{ needs.eval-changes.outputs.ci-changes }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Typing :: Typed",


### PR DESCRIPTION
## Summary by Sourcery

Add Python 3.14.0rc1 to the CI testing matrix and update package metadata to include Python 3.14 classifier

Build:
- Include Python 3.14.0rc1 in the GitHub Actions Python versions matrix

Documentation:
- Add "Programming Language :: Python :: 3.14" classifier in pyproject.toml