### PR TITLE
test: do not test against uvloop on python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       group: ${{ github.workflow }}-validate-${{ github.ref_name }}
       cancel-in-progress: true
     with:
-      python-versions: '[ "3.11", "3.12", "3.13" ]'
+      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.1"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
       ci-files-changed: ${{ needs.eval-changes.outputs.ci-changes }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.0,<0.9.0"]
+requires = ["uv_build>=0.8.9,<0.9.0"]
 build-backend = "uv_build"
 
 [project]
@@ -70,7 +70,7 @@ test = [
   "pytest-randomly>=3.16.0",
   "pytest-timeout>=2.4.0",
   "trio>=0.30.0",
-  "uvloop>=0.21.0; sys_platform != 'win32'",
+  "uvloop>=0.21.0; sys_platform != 'win32' and python_version < '3.14'",
 ]
 typecheck = [
   "basedpyright>=1.31.0",
@@ -81,7 +81,7 @@ typecheck = [
 # ----- UV settings -----
 [tool.uv]
 default-groups = "all"
-required-version = ">=0.8.0"
+required-version = ">=0.8.9"
 
 
 # ----- Pytest settings -----
@@ -271,7 +271,7 @@ exclude = [
 # ----- Semantic release settings -----
 [tool.semantic_release]
 build_command = """
-    command -v uv 2>/dev/null || pip install uv==0.8.3
+    command -v uv 2>/dev/null || pip install uv==0.8.9
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock
     uv build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,16 @@ if TYPE_CHECKING:
         pytest.param(
             ('asyncio', {'use_uvloop': True}),
             id='asyncio+uvloop',
-            marks=pytest.mark.skipif(
-                sys.platform.startswith('win'),
-                reason='uvloop does not support Windows',
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform.startswith('win'),
+                    reason='uvloop does not support Windows',
+                ),
+                pytest.mark.skipif(
+                    sys.version_info >= (3, 14),
+                    reason='uvloop does not support Python 3.14+',
+                ),
+            ],
         ),
         pytest.param(('asyncio', {'use_uvloop': False}), id='asyncio'),
         pytest.param(('trio', {'restrict_keyboard_interrupt_to_checkpoints': True}), id='trio'),

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -1494,7 +1494,7 @@ test = [
     { name = "pytest-randomly" },
     { name = "pytest-timeout" },
     { name = "trio" },
-    { name = "uvloop", marker = "sys_platform != 'win32'" },
+    { name = "uvloop", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
 ]
 typecheck = [
     { name = "basedpyright" },
@@ -1536,7 +1536,7 @@ test = [
     { name = "pytest-randomly", specifier = ">=3.16.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "trio", specifier = ">=0.30.0" },
-    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
+    { name = "uvloop", marker = "python_full_version < '3.14' and sys_platform != 'win32'", specifier = ">=0.21.0" },
 ]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.31.0" },


### PR DESCRIPTION
## Summary by Sourcery

Exclude uvloop from testing and dependencies on unsupported Python 3.14+ and Windows platforms

Enhancements:
- Skip uvloop-based tests on Python 3.14 or higher
- Restrict uvloop dependency to Python versions below 3.14 in pyproject.toml