### PR TITLE
ci: migrate from pre-commit to prek

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -162,7 +162,7 @@ jobs:
           enable-cache: true
 
       - name: Setup | Install dependencies
-        run: task install -- --no-group=docs
+        run: task deps:install -- --no-group=docs
 
       - name: Lint | Run all pre-commit hooks
         id: lint
@@ -214,7 +214,7 @@ jobs:
 
       - name: Setup | Install dependencies
         run: |
-          task install -- --no-group=docs
+          task deps:install -- --no-group=docs
           uv pip install pytest-github-actions-annotate-failures
 
       - name: Test | Run pytest on ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Before you begin, ensure you have the following installed:
 
     ```bash
     # Install dependencies and configure pre-commit hooks
-    task install
+    task deps:install
     ```
 
     > **Tip:** Run `task -l` after setup to verify everything is working and to see available commands.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
     silent: true
     cmds:
       - task: deps:sync
-      - uv run pre-commit install
+      - uv run prek install
       - echo "✅ Development environment setup complete"
 
   deps:sync:
@@ -62,7 +62,7 @@ tasks:
       - task: deps:sync
         vars:
           CLI_ARGS: --upgrade
-      - uv run pre-commit autoupdate
+      - uv run prek auto-update || true
       - echo "✅ Dependencies upgraded"
 
   deps:audit:
@@ -116,10 +116,11 @@ tasks:
     cmd: uv run pre-commit run codespell --all-files
 
   pre-commit-all:
+    aliases: [ prek ]
     desc: Run all pre-commit hooks against all files
     deps: [ .uv-locked ]
     silent: true
-    cmd: uv run pre-commit run --verbose --all-files --hook-stage manual
+    cmd: uv run prek run --verbose --all-files --hook-stage manual
 
   deptry:
     desc: Find unused, missing and transitive dependencies in project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ docs = [
 lint = [
   "deptry>=0.23.1",
   "gitlint>=0.19.1",
-  "pre-commit>=4.3.0",
+  "prek>=0.0.29",
   "ruff>=0.12.8",
 ]
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -99,15 +99,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -293,24 +284,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
-]
-
-[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -389,15 +362,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/0f/9cbd56eb047de77a4b93d8d4674e70cd19a1ff64d7410651b514a1ed93d5/griffe-1.11.1.tar.gz", hash = "sha256:d54ffad1ec4da9658901eb5521e9cddcdb7a496604f67d8ae71077f03f549b7e", size = 410996, upload-time = "2025-08-11T11:38:35.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/a3/451ffd422ce143758a39c0290aaa7c9727ecc2bcc19debd7a8f3c6075ce9/griffe-1.11.1-py3-none-any.whl", hash = "sha256:5799cf7c513e4b928cfc6107ee6c4bc4a92e001f07022d97fd8dee2f612b6064", size = 138745, upload-time = "2025-08-11T11:38:33.964Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ca/ffbabe3635bb839aa36b3a893c91a9b0d368cb4d8073e03a12896970af82/identify-2.6.13.tar.gz", hash = "sha256:da8d6c828e773620e13bfa86ea601c5a5310ba4bcd65edf378198b56a1f9fb32", size = 99243, upload-time = "2025-08-09T19:35:00.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl", hash = "sha256:60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b", size = 99153, upload-time = "2025-08-09T19:34:59.1Z" },
 ]
 
 [[package]]
@@ -732,15 +696,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "nodejs-wheel-binaries"
 version = "22.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -821,19 +776,29 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.3.0"
+name = "prek"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/4e/df67081be4196d1afd38063299f13eedf4de7e6c86f711c7019fa3fb81d4/prek-0.0.29.tar.gz", hash = "sha256:f6cbcb50308c91cda70952d02a6af9bbd685dfd26bf88e5db6752bf7e704e381", size = 178034, upload-time = "2025-08-18T15:10:08.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c7/c6030b81005fd01329a6f1ebb0a12b8c3c3fb6e7998e4b3e6c055ba565b0/prek-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:e80e7cce7e6317dad0aeb9ccc3802bc079b172ecc86b21c678098914e9b64616", size = 5561886, upload-time = "2025-08-18T15:09:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/34/30/bcf5ece0cd9abef8260658f740c05dc57b22f839e8d6e110fb4d66666a05/prek-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c873205f2cccd2d351219394a6c76e51de9af9e31866f6172aa2c2c3ad7ac28c", size = 5503412, upload-time = "2025-08-18T15:09:37.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7b/f1cb10a1fd4bf00deaa9de782efad64ab4fd3b7f56521a37e3524c8e3f9b/prek-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8e70edc31dc0ef44236211cc028c392101b9f5152bdb6c4813a8a909fe8c130a", size = 5311811, upload-time = "2025-08-18T15:09:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c1/e3b82ab1cee74d0dae16d00deec2ebd51466a29c3c9e0617c4a512995c87/prek-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:f7b0980d8f187aeb821a335ea81f32a0881aac21e701d9f847b5d1e1d86c82f5", size = 5716307, upload-time = "2025-08-18T15:09:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/32/87/f3f42646f305a0e0beda546ad52be17bc49c5d97a5dbdac12e95ec4beb7d/prek-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c77c8f121e3d05f8f36df98d900416b4d0e00b9d0f45c85f8d7ab96cc4d0d3c1", size = 5470609, upload-time = "2025-08-18T15:09:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/2478edd0411311c8ae2918e64d8415ec8a7070552efb5c0cef2fb9d722e8/prek-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc837db344c82c3e8713db1d5090624f25a8eb8666e1747563cd8fa6fdece062", size = 6110282, upload-time = "2025-08-18T15:09:44.592Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/77/e69b828d3386abee079d7e1c2d09ffbb7d48a37fa9964b0c7bea57e73b37/prek-0.0.29-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:727af43b8b09171f6d0555078f4c982a93545d4e209388f4e3bebac799fbe62c", size = 6753040, upload-time = "2025-08-18T15:09:45.983Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/0c0e86d2091f57782ee34437e1c4ef3df5b6e955c392ad353a91936f1b52/prek-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1dc95a7be6972439a0de09dd3d960e0a13a4193d1cff734be358c4db5c9a20cc", size = 6467549, upload-time = "2025-08-18T15:09:47.285Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/83/4e87af65a05e0da3c035aef7e2f0a79da439072a7b96316c0ed54610d7db/prek-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:be2f63c1fd56835dc98b80147746a12aee32c98a52069b35a632ea8f1a096762", size = 5897769, upload-time = "2025-08-18T15:09:48.991Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ec/b3bca63869b1b7d777e58fa5eb51d3cc4a31aa72a845cde85eb47e8fdf76/prek-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16f5acb17eca1e300a06a2d8a4b8ad4a69cc7346e9466cafc8f4b6b53646e90c", size = 5875408, upload-time = "2025-08-18T15:09:50.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/04/f38a0837b3906fe5f1c063b13b3d33fc40a6c4f11a9862b58d560f71742f/prek-0.0.29-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e02e3125ecf9bbb6622744b13d86ab55ab127a80ba679ac5cd1293cd2d387ea", size = 5757805, upload-time = "2025-08-18T15:09:51.874Z" },
+    { url = "https://files.pythonhosted.org/packages/56/2f/89f0e9ddf764c06eaf1f2f5920e608101c287dd9ee235a1aa48adf512971/prek-0.0.29-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a88e6eb83b49492fbb7fb4391e59960be69d9dcd3f756b53e2a0518c70dc1b2", size = 5800605, upload-time = "2025-08-18T15:09:53.129Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5e/2947fc6032b753231ead69e0c94e266d12c698741f8d4d5b6a86710c3b62/prek-0.0.29-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:146030f0b06ea51c7317577e172cf61326e5d9ea66ad7b0fa5e2d973e9a39394", size = 5479992, upload-time = "2025-08-18T15:09:54.454Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e4/43b2d2ff04a3692ca5981b661645c1374c0a2153f66876d79934bef0ae43/prek-0.0.29-py3-none-musllinux_1_1_i686.whl", hash = "sha256:a9c769253241f2f0b8ecdf9985a11a74c4a465e50d39c1382b90cf2e9ad21699", size = 5820793, upload-time = "2025-08-18T15:09:56.105Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/57085593a7a635d274b5debf470b2eab79269aaf9ce4903ae1c414b4d787/prek-0.0.29-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:da2e8d4147ba72ae86c97594ccde20fe3c1f7fa6f68508c935528100d2d6da24", size = 5961485, upload-time = "2025-08-18T15:09:58.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1d/90d907950441347c297e3d362da0029c4d012e5ada711e97daa78776a12d/prek-0.0.29-py3-none-win32.whl", hash = "sha256:3ccdc581461a8606944c42852ddc57e3f9f460be7b3d89b563dd66a2b77d02f1", size = 4255950, upload-time = "2025-08-18T15:10:02.811Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a5/df30c4226349577676d1801e1e9ad2f640e35342865da1df68e995229ed5/prek-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fd876da9390f3e6c6ed793bf2d23ac111fa8564b44f7c435f3c0e8e7fcaf138c", size = 4772492, upload-time = "2025-08-18T15:10:05.23Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c9/0914dfe923adbcfeaadf18aea6a191b1271ae81b617acfcd47cf6aab3a7c/prek-0.0.29-py3-none-win_arm64.whl", hash = "sha256:bc7678985f2110a9c3c6a89276664741c3f758fb519c1d0e25443c3ba0855d54", size = 4524542, upload-time = "2025-08-18T15:10:06.562Z" },
 ]
 
 [[package]]
@@ -1271,20 +1236,6 @@ wheels = [
 ]
 
 [[package]]
-name = "virtualenv"
-version = "20.33.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/60/4f20960df6c7b363a18a55ab034c8f2bcd5d9770d1f94f9370ec104c1855/virtualenv-20.33.1.tar.gz", hash = "sha256:1b44478d9e261b3fb8baa5e74a0ca3bc0e05f21aa36167bf9cbf850e542765b8", size = 6082160, upload-time = "2025-08-05T16:10:55.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/ff/ded57ac5ff40a09e6e198550bab075d780941e0b0f83cbeabd087c59383a/virtualenv-20.33.1-py3-none-any.whl", hash = "sha256:07c19bc66c11acab6a5958b815cbcee30891cd1c2ccf53785a28651a0d8d8a67", size = 6060362, upload-time = "2025-08-05T16:10:52.81Z" },
-]
-
-[[package]]
 name = "waku"
 version = "0.21.0"
 source = { editable = "." }
@@ -1310,7 +1261,7 @@ docs = [
 lint = [
     { name = "deptry" },
     { name = "gitlint" },
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "ruff" },
 ]
 test = [
@@ -1352,7 +1303,7 @@ docs = [
 lint = [
     { name = "deptry", specifier = ">=0.23.1" },
     { name = "gitlint", specifier = ">=0.19.1" },
-    { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "prek", specifier = ">=0.0.29" },
     { name = "ruff", specifier = ">=0.12.8" },
 ]
 test = [


### PR DESCRIPTION
## Summary by Sourcery

Migrate from pre-commit to prek for local hooks and CI, updating configuration, scripts, and docs accordingly

Enhancements:
- Replace pre-commit commands with prek in Taskfile and project config
- Update pyproject.toml to depend on prek instead of pre-commit

CI:
- Adjust GitHub Actions workflows to use deps:install and prek commands instead of pre-commit

Documentation:
- Update CONTRIBUTING.md to reflect deps:install usage instead of task install