### PR TITLE
ci: up python 3.14 to rc 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
     needs: eval-changes
     with:
-      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.1"]'
+      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.2"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
       ci-files-changed: ${{ needs.eval-changes.outputs.ci-changes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       group: ${{ github.workflow }}-validate-${{ github.ref_name }}
       cancel-in-progress: true
     with:
-      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.1"]'
+      python-versions: '[ "3.11", "3.12", "3.13", "3.14.0-rc.2"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
       ci-files-changed: ${{ needs.eval-changes.outputs.ci-changes }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
                 ),
                 pytest.mark.skipif(
                     sys.version_info >= (3, 14),
-                    reason='uvloop does not support Python 3.14+',
+                    reason='uvloop does not yet support Python 3.14+',
                 ),
             ],
         ),


### PR DESCRIPTION
## Summary by Sourcery

Bump Python 3.14 prerelease version to rc.2 across CI and release workflows and update test skip reason for uvloop support

CI:
- Update Python matrix versions in CI and release workflows to include 3.14.0-rc.2

Tests:
- Adjust uvloop skip reason to indicate it does not yet support Python 3.14+